### PR TITLE
correcting batch division and stripping some whitespace

### DIFF
--- a/.ipynb_checkpoints/2. Define the Network Architecture-checkpoint.ipynb
+++ b/.ipynb_checkpoints/2. Define the Network Architecture-checkpoint.ipynb
@@ -126,9 +126,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "## Transform the dataset \n",
     "\n",
@@ -152,7 +150,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": true
    },
    "outputs": [],
    "source": [
@@ -177,7 +176,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -213,7 +213,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -223,7 +224,7 @@
     "train_loader = DataLoader(transformed_dataset, \n",
     "                          batch_size=batch_size,\n",
     "                          shuffle=True, \n",
-    "                          num_workers=4)\n"
+    "                          num_workers=4)"
    ]
   },
   {
@@ -245,7 +246,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -255,15 +257,15 @@
     "# create the test dataset\n",
     "test_dataset = FacialKeypointsDataset(csv_file='data/test_frames_keypoints.csv',\n",
     "                                             root_dir='data/test/',\n",
-    "                                             transform=data_transform)\n",
-    "\n"
+    "                                             transform=data_transform)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -294,7 +296,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -337,7 +340,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -366,7 +370,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -395,7 +400,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -455,7 +461,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": true
    },
    "outputs": [],
    "source": [
@@ -484,10 +491,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
+    "n_batches = 10\n",
     "def train_net(n_epochs):\n",
     "\n",
     "    # prepare the net for training\n",
@@ -528,8 +537,8 @@
     "            # print loss statistics\n",
     "            # to convert loss into a scalar and add it to the running_loss, use .item()\n",
     "            running_loss += loss.item()\n",
-    "            if batch_i % 10 == 9:    # print every 10 batches\n",
-    "                print('Epoch: {}, Batch: {}, Avg. Loss: {}'.format(epoch + 1, batch_i+1, running_loss/1000))\n",
+    "            if batch_i % n_batches == (n_batches - 1):    # print every 10 batches\n",
+    "                print('Epoch: {}, Batch: {}, Avg. Loss: {}'.format(epoch + 1, batch_i + 1, running_loss / n_batches))\n",
     "                running_loss = 0.0\n",
     "\n",
     "    print('Finished Training')\n"
@@ -539,7 +548,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": true
    },
    "outputs": [],
    "source": [
@@ -562,7 +572,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -578,7 +589,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": true
    },
    "outputs": [],
    "source": [
@@ -599,7 +611,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -620,44 +633,68 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "gradable": true,
+    "type": "question"
+   },
    "source": [
     "### Question 1: What optimization and loss functions did you choose and why?\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "gradable": true,
+    "type": "question"
+   },
    "source": [
-    "**Answer**: write your answer here (double click to edit this cell)"
+    "**Answer**: \n",
+    "\n",
+    "*write your answer here (double click to edit this cell)*"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "gradable": true,
+    "type": "question"
+   },
    "source": [
     "### Question 2: What kind of network architecture did you start with and how did it change as you tried different architectures? Did you decide to add more convolutional layers or any layers to avoid overfitting the data?"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "gradable": true,
+    "type": "question"
+   },
    "source": [
-    "**Answer**: write your answer here"
+    "**Answer**: \n",
+    "\n",
+    "*write your answer here (double click to edit this cell)*"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "gradable": true,
+    "type": "question"
+   },
    "source": [
     "### Question 3: How did you decide on the number of epochs and batch_size to train your model?"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "gradable": true,
+    "type": "question"
+   },
    "source": [
-    "**Answer**: write your answer here"
+    "**Answer**: \n",
+    "\n",
+    "*write your answer here (double click to edit this cell)*"
    ]
   },
   {
@@ -680,7 +717,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -720,7 +758,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": true
    },
    "outputs": [],
    "source": [
@@ -732,16 +771,24 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "gradable": true,
+    "type": "question"
+   },
    "source": [
     "### Question 4: Choose one filter from your trained CNN and apply it to a test image; what purpose do you think it plays? What kind of feature do you think it detects?\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "gradable": true,
+    "type": "question"
+   },
    "source": [
-    "**Answer**: (does it detect vertical lines or does it blur out noise, etc.) write your answer here"
+    "**Answer**: (does it detect vertical lines or does it blur out noise, etc.) \n",
+    "\n",
+    "*write your answer here*"
    ]
   },
   {
@@ -757,9 +804,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:ai]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-ai-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -771,7 +818,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/.ipynb_checkpoints/3. Facial Keypoint Detection, Complete Pipeline-checkpoint.ipynb
+++ b/.ipynb_checkpoints/3. Facial Keypoint Detection, Complete Pipeline-checkpoint.ipynb
@@ -26,14 +26,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "import matplotlib.image as mpimg\n",
-    "%matplotlib inline\n"
+    "%matplotlib inline"
    ]
   },
   {
@@ -49,7 +50,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -85,7 +87,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -126,7 +129,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": true
    },
    "outputs": [],
    "source": [
@@ -175,7 +179,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": true
    },
    "outputs": [],
    "source": [
@@ -205,9 +210,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:ai]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-ai-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -219,9 +224,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/2. Define the Network Architecture.ipynb
+++ b/2. Define the Network Architecture.ipynb
@@ -126,9 +126,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "## Transform the dataset \n",
     "\n",
@@ -152,7 +150,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": true
    },
    "outputs": [],
    "source": [
@@ -177,7 +176,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -213,7 +213,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -223,7 +224,7 @@
     "train_loader = DataLoader(transformed_dataset, \n",
     "                          batch_size=batch_size,\n",
     "                          shuffle=True, \n",
-    "                          num_workers=4)\n"
+    "                          num_workers=4)"
    ]
   },
   {
@@ -245,7 +246,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -255,15 +257,15 @@
     "# create the test dataset\n",
     "test_dataset = FacialKeypointsDataset(csv_file='data/test_frames_keypoints.csv',\n",
     "                                             root_dir='data/test/',\n",
-    "                                             transform=data_transform)\n",
-    "\n"
+    "                                             transform=data_transform)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -294,7 +296,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -337,7 +340,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -366,7 +370,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -395,7 +400,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -455,7 +461,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": true
    },
    "outputs": [],
    "source": [
@@ -484,10 +491,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
+    "n_batches = 10\n",
     "def train_net(n_epochs):\n",
     "\n",
     "    # prepare the net for training\n",
@@ -528,8 +537,8 @@
     "            # print loss statistics\n",
     "            # to convert loss into a scalar and add it to the running_loss, use .item()\n",
     "            running_loss += loss.item()\n",
-    "            if batch_i % 10 == 9:    # print every 10 batches\n",
-    "                print('Epoch: {}, Batch: {}, Avg. Loss: {}'.format(epoch + 1, batch_i+1, running_loss/1000))\n",
+    "            if batch_i % n_batches == (n_batches - 1):    # print every 10 batches\n",
+    "                print('Epoch: {}, Batch: {}, Avg. Loss: {}'.format(epoch + 1, batch_i + 1, running_loss / n_batches))\n",
     "                running_loss = 0.0\n",
     "\n",
     "    print('Finished Training')\n"
@@ -539,7 +548,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": true
    },
    "outputs": [],
    "source": [
@@ -562,7 +572,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -578,7 +589,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": true
    },
    "outputs": [],
    "source": [
@@ -599,7 +611,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -620,44 +633,68 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "gradable": true,
+    "type": "question"
+   },
    "source": [
     "### Question 1: What optimization and loss functions did you choose and why?\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "gradable": true,
+    "type": "question"
+   },
    "source": [
-    "**Answer**: write your answer here (double click to edit this cell)"
+    "**Answer**: \n",
+    "\n",
+    "*write your answer here (double click to edit this cell)*"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "gradable": true,
+    "type": "question"
+   },
    "source": [
     "### Question 2: What kind of network architecture did you start with and how did it change as you tried different architectures? Did you decide to add more convolutional layers or any layers to avoid overfitting the data?"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "gradable": true,
+    "type": "question"
+   },
    "source": [
-    "**Answer**: write your answer here"
+    "**Answer**: \n",
+    "\n",
+    "*write your answer here (double click to edit this cell)*"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "gradable": true,
+    "type": "question"
+   },
    "source": [
     "### Question 3: How did you decide on the number of epochs and batch_size to train your model?"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "gradable": true,
+    "type": "question"
+   },
    "source": [
-    "**Answer**: write your answer here"
+    "**Answer**: \n",
+    "\n",
+    "*write your answer here (double click to edit this cell)*"
    ]
   },
   {
@@ -680,7 +717,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -720,7 +758,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": true
    },
    "outputs": [],
    "source": [
@@ -732,16 +771,24 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "gradable": true,
+    "type": "question"
+   },
    "source": [
     "### Question 4: Choose one filter from your trained CNN and apply it to a test image; what purpose do you think it plays? What kind of feature do you think it detects?\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "gradable": true,
+    "type": "question"
+   },
    "source": [
-    "**Answer**: (does it detect vertical lines or does it blur out noise, etc.) write your answer here"
+    "**Answer**: (does it detect vertical lines or does it blur out noise, etc.) \n",
+    "\n",
+    "*write your answer here*"
    ]
   },
   {
@@ -757,9 +804,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:ai]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-ai-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -771,7 +818,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/3. Facial Keypoint Detection, Complete Pipeline.ipynb
+++ b/3. Facial Keypoint Detection, Complete Pipeline.ipynb
@@ -26,14 +26,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "import matplotlib.image as mpimg\n",
-    "%matplotlib inline\n"
+    "%matplotlib inline"
    ]
   },
   {
@@ -49,7 +50,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -85,7 +87,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": false
    },
    "outputs": [],
    "source": [
@@ -126,7 +129,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": true
    },
    "outputs": [],
    "source": [
@@ -175,7 +179,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "gradable": true
    },
    "outputs": [],
    "source": [
@@ -205,9 +210,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:ai]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-ai-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -219,9 +224,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }


### PR DESCRIPTION
@cezannec seemed to be errata for a while – in the training loop, every 10 epochs, progress is printed, however... code read out:

```python
running_loss += loss.item()
if batch_i % 10 == 9:    # print every 10 batches
    print("Epoch: {}, Batch: {}, Avg. Loss: {}".format(epoch + 1, batch_i+1, running_loss/1000))
    running_loss = 0.0
```

corrected it to read out:
```python
running_loss += loss.item()
if batch_i % n_batches == (n_batches - 1):    # print every 10 batches
    print("Epoch: {}, Batch: {}, Avg. Loss: {}".format(epoch + 1, batch_i + 1, running_loss / n_batches))
    running_loss = 0.0
```

replaced `/ 1000` with `n_batches`, so that it becomes a little more obvious to students, especially so that they understand what `/1000` means. (Few of them seemed to actually realize what this is.) Correction spurred by corrections to Workspaces, or at least what appear to be corrections – might be a good idea to have the git repos function as the source for Workspaces' code? (Apparently, doesn't appear to be. :confused:)