### PR TITLE
Removed normalization of key points

### DIFF
--- a/data_load.py
+++ b/data_load.py
@@ -67,7 +67,7 @@ class Normalize(object):
         
         # scale keypoints to be centered around 0 with a range of [-1, 1]
         # mean = 100, sqrt = 50, so, pts should be (pts - 100)/50
-        key_pts_copy = (key_pts_copy - 100)/50.0
+#         key_pts_copy = (key_pts_copy - 100)/50.0
 
 
         return {'image': image_copy, 'keypoints': key_pts_copy}


### PR DESCRIPTION
When we are normalizing an image, we are normalizing the pixel intensity values, the size of the image remains the same.
Hence the key points are not changing their positions. w.r.t to the image. Their values must remain the same.